### PR TITLE
Allow custom values alongside custom labels

### DIFF
--- a/src/components/FormControl.vue
+++ b/src/components/FormControl.vue
@@ -137,7 +137,7 @@ if (props.ctrlKFocus) {
       <option
         v-for="option in options"
         :key="option.id ?? option"
-        :value="option"
+        :value="option.value ?? option"
       >
         {{ option.label ?? option }}
       </option>


### PR DESCRIPTION
Hello,

This is a small change that allows the usage of custom values for FormControls.

Currently, you can't have a custom label and a value together.